### PR TITLE
Support Ruby 3

### DIFF
--- a/lib/fortschritt.rb
+++ b/lib/fortschritt.rb
@@ -8,8 +8,8 @@ module Fortschritt
     @meter and @meter.increment
   end
 
-  def self.init(total, opts = {})
-    @meter = Fortschritt::Meter.new(total, opts)
+  def self.init(total, silent: false)
+    @meter = Fortschritt::Meter.new(total, silent: silent)
   end
 
   def self.printer

--- a/lib/fortschritt/enumerable.rb
+++ b/lib/fortschritt/enumerable.rb
@@ -1,6 +1,6 @@
 module Enumerable
-  def with_fortschritt(opts = {})
-    Fortschritt.init(size, opts)
+  def with_fortschritt(**opts)
+    Fortschritt.init(size, **opts)
     self
   end
 end
@@ -17,8 +17,8 @@ if defined?(Rails)
 
     extend ActiveSupport::Concern
 
-    def with_fortschritt(opts = {})
-      Fortschritt.init(size, opts)
+    def with_fortschritt(**opts)
+      Fortschritt.init(size, **opts)
       self
     end
   end


### PR DESCRIPTION
fixes `#<ArgumentError: wrong number of arguments (given 2, expected 1)>` in meter.rb:5