### PR TITLE
Debounce meter printing

### DIFF
--- a/lib/fortschritt/meter.rb
+++ b/lib/fortschritt/meter.rb
@@ -9,6 +9,7 @@ module Fortschritt
       @average_seconds = 0
       @started_at      = Time.now
       @silent          = silent || !!(Rails.env.test? if defined?(Rails))
+      @printed_at      = Time.now
     end
 
     def increment
@@ -17,7 +18,7 @@ module Fortschritt
       @average_seconds = calculate_average_seconds(elapsed_seconds)
       @updated_at      = @_now
       @done           += 1
-      print! unless @silent
+      print! unless @silent || debounce?
     end
 
     def completed?
@@ -43,6 +44,13 @@ module Fortschritt
 
     def print!
       Fortschritt.printer.print(self)
+    end
+
+    def debounce?
+      return true if @updated_at - @printed_at < 0.01 && !completed?
+
+      @printed_at = @updated_at
+      false
     end
   end
 end


### PR DESCRIPTION
while running a regexp against 6.5M email addresses in memory, i noticed that fortschritt slowed down things by orders of magnitude.

this is because it waits for every step to be printed to stdout, which can be the slowest thing in a fast iteration:

```ruby
Benchmark.measure { (1..10_000_000).each { _1 * 2 } }.real
# => 0.2504019998013973

# with fortschritt
Benchmark.measure { (1..10_000_000).with_fortschritt.each { _1 * 2.fortschritt } }.real
# => 113.91912900097668

# after this PR
Benchmark.measure { (1..10_000_000).with_fortschritt.each { _1 * 2.fortschritt } }.real
# => 4.500468000769615
```