### PR TITLE
Show hour values above 23 ...

### DIFF
--- a/lib/fortschritt/printer.rb
+++ b/lib/fortschritt/printer.rb
@@ -38,12 +38,9 @@ module Fortschritt
 
     private
 
-    # "%d days, %d hours, %d minutes and %d seconds" % [dd, hh, mm, ss]
-    #=> 3 days, 3 hours, 15 minutes and 21 seconds
     def format_seconds(seconds)
       mm, ss = seconds.divmod(60)
       hh, mm = mm.divmod(60)
-      dd, hh = hh.divmod(24)
       "%02d:%02d:%02d" % [hh, mm, ss]
     end
   end


### PR DESCRIPTION
e.g. for a task that takes 24h and 5m, the current output is

```
22732/4449560 → 00:05:00 → ETA [...]
```

after the change:

```
22732/4449560 → 24:05:00 → ETA [...]
```

the format specifier `%nd` only sets a minimum width, so this also works for very long running tasks with more than two digits of hours.