### PR TITLE
Support blocks and generic Enumerables

### DIFF
--- a/fortschritt.gemspec
+++ b/fortschritt.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "> 1.10"
-  spec.add_development_dependency "rake", "~> 12.3.3"
+  spec.add_development_dependency "rake", "~> 13.3"
   spec.add_development_dependency "rspec"
 end

--- a/lib/fortschritt/enumerable.rb
+++ b/lib/fortschritt/enumerable.rb
@@ -1,7 +1,7 @@
 module Enumerable
-  def with_fortschritt(**opts)
-    Fortschritt.init(size, **opts)
-    self
+  def with_fortschritt(**opts, &block)
+    Fortschritt.init(count, **opts)
+    block ? each(&block) : self
   end
 end
 
@@ -14,9 +14,9 @@ end
 
 if defined?(Rails)
   module Fortschritt::ActiveRecordExtension
-    def with_fortschritt(**opts)
-      Fortschritt.init(size, **opts)
-      self
+    def with_fortschritt(**opts, &block)
+      Fortschritt.init(count, **opts)
+      block ? find_each(&block) : self
     end
   end
 


### PR DESCRIPTION
Supporting blocks allows chaining `with_fortschritt` at the end, e.g.

```ruby
User.with_fortschritt(&:delete)
```

Using `#count` instead of `#size` adds support for generic Enumerable objects (which only implement `#count` by default).

E.g.

```ruby
User.count # => 3
User.in_batches.size # => undefined method 'size' for an instance of ActiveRecord::Batches::BatchEnumerator
User.in_batches.count # => 1
```